### PR TITLE
[Fix] clean.sh の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ latexmk is avaiable to typeset without modifying your `.latexmkrc`.
 latexmk use a `.latexmkrc` on the current direcotry.
 
 ```
+./clean.sh # to export $TEXINPUT
 latexmk -pvc main.tex
 ```
 

--- a/clean.sh
+++ b/clean.sh
@@ -1,2 +1,3 @@
 #!bin/bash
 rm *.aux *.dvi *.fdb_latexmk *.fls *.log *.pdf *.synctex.gz *.toc
+export TEXINPUTS='.//;'


### PR DESCRIPTION
## 修正した問題
`y-jbook.cls not found` の旨のエラーが発生する

## 原因
サブディレクトリ `y-jbook` を検索対象にしていないこと。

## 解決方法
clean.sh に環境変数 TEXINPUTS を export する処理を追加。

## 使用方法の変更
Windows ユーザには影響なし。
*NIX ユーザは、(シェルにログインしてから最初だけ) `clean.sh` を実行する。

```
./clean.sh
latexmk -pvc hogehoge.tex
```